### PR TITLE
Fix Program.cs logging fatal exception

### DIFF
--- a/api/server/Program.cs
+++ b/api/server/Program.cs
@@ -20,7 +20,7 @@ try
 catch (Exception ex) when (!ex.GetType().Name.Equals("HostAbortedException", StringComparison.Ordinal))
 {
     StaticLogger.EnsureInitialized();
-    Log.Fatal(ex.Message, "unhandled exception");
+    Log.Fatal(ex, "unhandled exception");
 }
 finally
 {


### PR DESCRIPTION
## Summary
- log the full exception object when an unhandled exception occurs

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684456929a9c8329b65723b4b5a666b7