### PR TITLE
Add JwtOptions tests

### DIFF
--- a/NexKoala.API.sln
+++ b/NexKoala.API.sln
@@ -45,11 +45,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Catalog.Infrastructure", "a
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Invoice", "Invoice", "{F49B3A47-1251-4C5C-B1FA-52EB931236FC}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{C5ED2256-0D67-433A-933F-78D2167CC3D1}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Invoice.Application", "api\modules\Invoice\Invoice.Application\Invoice.Application.csproj", "{B525AF17-3334-4824-8E1A-97E7EE9B10A6}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Invoice.Domain", "api\modules\Invoice\Invoice.Domain\Invoice.Domain.csproj", "{39CC3389-1660-4CAA-9E68-42C3B789CC24}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Invoice.Infrastructure", "api\modules\Invoice\Invoice.Infrastructure\Invoice.Infrastructure.csproj", "{DD643628-175D-4F9E-A371-A13F5C1A4692}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core.Tests", "tests\Core.Tests\Core.Tests.csproj", "{C9153EEF-F937-40F1-8473-F28F80B191C7}"
 EndProject
 
 Global
@@ -253,9 +257,11 @@ Global
 		{F49B3A47-1251-4C5C-B1FA-52EB931236FC} = {F3DF5AC5-8CDC-46D4-969D-1245A6880215}
 		{B525AF17-3334-4824-8E1A-97E7EE9B10A6} = {F49B3A47-1251-4C5C-B1FA-52EB931236FC}
 		{39CC3389-1660-4CAA-9E68-42C3B789CC24} = {F49B3A47-1251-4C5C-B1FA-52EB931236FC}
-		{DD643628-175D-4F9E-A371-A13F5C1A4692} = {F49B3A47-1251-4C5C-B1FA-52EB931236FC}
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {EA8248C2-3877-4AF7-8777-A17E7881E030}
-	EndGlobalSection
+                {DD643628-175D-4F9E-A371-A13F5C1A4692} = {F49B3A47-1251-4C5C-B1FA-52EB931236FC}
+                {C5ED2256-0D67-433A-933F-78D2167CC3D1} = {CE64E92B-E088-46FB-9028-7FB6B67DEC55}
+                {C9153EEF-F937-40F1-8473-F28F80B191C7} = {C5ED2256-0D67-433A-933F-78D2167CC3D1}
+        EndGlobalSection
+        GlobalSection(ExtensibilityGlobals) = postSolution
+                SolutionGuid = {EA8248C2-3877-4AF7-8777-A17E7881E030}
+        EndGlobalSection
 EndGlobal

--- a/tests/Core.Tests/Core.Tests.csproj
+++ b/tests/Core.Tests/Core.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../api/framework/Core/Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Core.Tests/Jwt/JwtOptionsTests.cs
+++ b/tests/Core.Tests/Jwt/JwtOptionsTests.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using NexKoala.Framework.Core.Auth.Jwt;
+using Xunit;
+
+namespace NexKoala.Framework.Core.Tests.Jwt;
+
+public class JwtOptionsTests
+{
+    [Fact]
+    public void Validate_ReturnsErrorWhenKeyIsEmpty()
+    {
+        var options = new JwtOptions { Key = string.Empty };
+        var result = options.Validate(new ValidationContext(options)).ToList();
+        Assert.Single(result);
+        Assert.Equal("Key", result[0].MemberNames.Single());
+    }
+
+    [Fact]
+    public void Validate_ReturnsNoErrorsWhenKeyProvided()
+    {
+        var options = new JwtOptions { Key = "secret" };
+        var result = options.Validate(new ValidationContext(options)).ToList();
+        Assert.Empty(result);
+    }
+}


### PR DESCRIPTION
## Summary
- create **Core.Tests** project referencing the Core library
- validate `JwtOptions` to ensure `Key` is required
- add test project to solution

## Testing
- `dotnet test tests/Core.Tests/Core.Tests.csproj -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445694a7f48329968ee96fd68f7362