### PR TITLE
Add tests for TodoItem domain and role utilities

### DIFF
--- a/tests/Core.Tests/Authorization/RolesTests.cs
+++ b/tests/Core.Tests/Authorization/RolesTests.cs
@@ -1,0 +1,17 @@
+using NexKoala.WebApi.Shared.Authorization;
+using Xunit;
+
+namespace NexKoala.Framework.Core.Tests.Authorization;
+
+public class RolesTests
+{
+    [Theory]
+    [InlineData(Roles.Admin, true)]
+    [InlineData(Roles.Basic, true)]
+    [InlineData("Other", false)]
+    public void IsDefault_ReturnsExpectedValue(string role, bool expected)
+    {
+        var result = Roles.IsDefault(role);
+        Assert.Equal(expected, result);
+    }
+}

--- a/tests/Core.Tests/Todo/TodoItemTests.cs
+++ b/tests/Core.Tests/Todo/TodoItemTests.cs
@@ -1,0 +1,39 @@
+using NexKoala.WebApi.Todo.Domain;
+using NexKoala.WebApi.Todo.Domain.Events;
+using Xunit;
+
+namespace NexKoala.Framework.Core.Tests.Todo;
+
+public class TodoItemTests
+{
+    [Fact]
+    public void Create_SetsPropertiesAndQueuesDomainEvent()
+    {
+        var item = TodoItem.Create("title", "note");
+
+        Assert.Equal("title", item.Title);
+        Assert.Equal("note", item.Note);
+        var domainEvent = Assert.Single(item.DomainEvents);
+        Assert.IsType<TodoItemCreated>(domainEvent);
+        var created = (TodoItemCreated)domainEvent;
+        Assert.Equal(item.Id, created.Id);
+        Assert.Equal("title", created.Title);
+        Assert.Equal("note", created.Note);
+    }
+
+    [Fact]
+    public void Update_ChangesValuesAndQueuesDomainEvent()
+    {
+        var item = TodoItem.Create("old", "old note");
+        item.DomainEvents.Clear();
+
+        item.Update("new", "new note");
+
+        Assert.Equal("new", item.Title);
+        Assert.Equal("new note", item.Note);
+        var domainEvent = Assert.Single(item.DomainEvents);
+        Assert.IsType<TodoItemUpdated>(domainEvent);
+        var updated = (TodoItemUpdated)domainEvent;
+        Assert.Equal(item, updated.item);
+    }
+}


### PR DESCRIPTION
## Summary
- add `TodoItemTests` to verify domain events on create and update
- add `RolesTests` to check default role detection

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844597acd9483298abc96f90b89e271