### PR TITLE
Add project references for Shared and Todo

### DIFF
--- a/tests/Core.Tests/Core.Tests.csproj
+++ b/tests/Core.Tests/Core.Tests.csproj
@@ -11,5 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../api/framework/Core/Core.csproj" />
+    <ProjectReference Include="../../api/modules/Shared/Shared.csproj" />
+    <ProjectReference Include="../../api/modules/Todo/Todo.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- include Shared and Todo module csproj in Core.Tests project references

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445bb594148329a7ccd8e1d1901603